### PR TITLE
chore: add room-migration skill for safe schema changes

### DIFF
--- a/.claude/skills/room-migration/SKILL.md
+++ b/.claude/skills/room-migration/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: room-migration
+description: Use when any Room @Entity, @Dao, or HavenDatabase.kt changes require a schema version bump and migration
+---
+
+When a Room schema change is needed, follow these steps in order:
+
+1. **Identify the change** — which entity field is being added/removed/renamed?
+2. **Increment version** in `HavenDatabase.kt` `@Database(version = N)`
+3. **Write the Migration object:**
+   val MIGRATION_N_TO_M = object : Migration(N, M) {
+       override fun migrate(db: SupportSQLiteDatabase) {
+           // ALTER TABLE or CREATE TABLE statement
+       }
+   }
+4. **Register it** in the database builder: `.addMigrations(MIGRATION_N_TO_M)`
+5. **Never use** `fallbackToDestructiveMigration()` — user data must survive
+6. **Seed data check** — if adding a new seed item, give it the new `SeedData.VERSION` value and use `INSERT OR IGNORE`
+7. **Export schema** — Room auto-exports to `app/schemas/` via the KSP config already set; commit the new JSON file
+8. **Write a migration test** using `MigrationTestHelper` from `room.testing`
+
+After completing all steps, run `./gradlew testDebugUnitTest` to verify.


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/room-migration/SKILL.md` — a user-invocable `/room-migration` skill
- Enforces the full Room migration checklist: version bump, migration object, registration, no destructive fallback, seed data check, schema export, and migration test
- Closes #14

## Test plan

- [ ] Invoke `/room-migration` in Claude Code and confirm the skill loads with the 8-step checklist
- [ ] Verify the skill name and description in the frontmatter match the invocation pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)