### PR TITLE
chore: add migration safety hook to catch schema edits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 -c \"import sys, json\ndata = json.load(sys.stdin)\npath = data.get('tool_input', {}).get('file_path', '')\nif any(x in path for x in ['data/entity', 'data/dao', 'HavenDatabase']):\n    print('MIGRATION SAFETY CHECK: This file affects the Room schema. Invoke the room-migration skill for the full checklist, or verify manually: (1) database version incremented in HavenDatabase.kt, (2) Migration object written, (3) seed data uses INSERT OR IGNORE with correct seedVersion gating.')\n\""
+            "command": "python3 -c \"import sys, json\ndata = json.load(sys.stdin)\npath = data.get('tool_input', {}).get('file_path', '')\nif any(x in path for x in ['data/entity', 'data/dao', 'HavenDatabase']):\n    print('MIGRATION SAFETY CHECK: This file affects the Room schema. Invoke the room-migration skill for the full checklist, or verify manually: (1) database version incremented in HavenDatabase.kt, (2) Migration object written, (3) seed data uses INSERT OR IGNORE with correct seedVersion gating, (4) schema JSON committed from app/schemas/, (5) MigrationTestHelper test written.')\n\""
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with a `PostToolUse` hook that triggers on any `Edit` or `Write` to files in `data/entity/`, `data/dao/`, or `HavenDatabase.kt`
- When triggered, injects a migration checklist reminder into Claude's context: bump DB version, write Migration object, gate seed data with `seedVersion`
- Zero latency — no Gradle invocation, pure context injection

Closes #15

## Test plan

- [ ] Edit any file under `data/entity/` or `data/dao/` in a Claude Code session and confirm the `MIGRATION SAFETY CHECK` message appears in context
- [ ] Confirm `settings.local.json` remains untracked (covered by global gitignore)
- [ ] Confirm `settings.json` is committed and visible to all contributors

🤖 Generated with [Claude Code](https://claude.com/claude-code)