### PR TITLE
chore: add workflow rules for branch discipline and worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ Key docs: `docs/spec.md` (feature spec), `docs/roadmap.md` (what's next), `docs/
 - Each PR gets one row in the `docs/changelog.md` table with the merge date, PR number, and a concise summary
 - As roadmap features are completed, collapse them in `docs/roadmap.md` and move the detail to the changelog
 - Link issues to PRs with `Closes #N` in the PR body — GitHub will auto-close the issue when the PR merges. Never close issues manually.
+- **Never commit directly to `main`.** All changes go through a feature branch and PR, no exceptions.
+- **Don't use git worktrees** unless explicitly asked. Check out branches normally so the user can see current work.
 
 ## Coding Conventions
 


### PR DESCRIPTION
## Summary

- Never commit directly to `main` — all changes via branch + PR
- Don't use git worktrees by default; checkout branches normally

Closes #21

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>